### PR TITLE
Add support for Laravel 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,11 @@
         }
     },
     "require": {
-        "php": ">=7.0.0",
-        "illuminate/support": "^5.4"
+        "php": ">=7.1.0",
+        "illuminate/support": "^5.4|^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.5",
+        "orchestra/testbench": "~3.5|^4.0",
         "friendsofphp/php-cs-fixer": "^2.3"
     },
     "autoload-dev": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          verbose="true"
         >
     <testsuites>
@@ -24,7 +23,7 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage" />
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,7 +8,7 @@ use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
Not sure about the coverage configuration, got warnings for the other flags but could't find how to properly configure it for phpunit 8.

Increased PHP version to 7.1 to enable the :void return type and support phpunit 8.