### PR TITLE
Support Laravel 13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,9 @@ jobs:
             fail-fast: false
             matrix:
               php: [8.1, 8.2, 8.3, 8.4]
-              laravel: [9.*, 10.*, 11.*, 12.*, 13.*]
+              laravel: [10.*, 11.*, 12.*, 13.*]
               dependency-version: [prefer-lowest, prefer-stable]
               include:
-                - laravel: 9.*
-                  testbench: ^7.0
                 - laravel: 10.*
                   testbench: ^8.20
                 - laravel: 11.*
@@ -26,7 +24,6 @@ jobs:
                 - laravel: 13.*
                   testbench: ^11.0
               exclude:
-                - laravel: 9.*
                 - php: 8.1
                   laravel: 11.*
                 - php: 8.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,7 @@ jobs:
                 - laravel: 13.*
                   testbench: ^11.0
               exclude:
-                - php: 8.3
-                  laravel: 9.*
+                - laravel: 9.*
                 - php: 8.1
                   laravel: 11.*
                 - php: 8.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
             fail-fast: false
             matrix:
               php: [8.1, 8.2, 8.3, 8.4]
-              laravel: [9.*, 10.*, 11.*, 12.*]
+              laravel: [9.*, 10.*, 11.*, 12.*, 13.*]
               dependency-version: [prefer-lowest, prefer-stable]
               include:
                 - laravel: 9.*
@@ -23,6 +23,8 @@ jobs:
                   testbench: ^9.0
                 - laravel: 12.*
                   testbench: ^10.0
+                - laravel: 13.*
+                  testbench: ^11.0
               exclude:
                 - php: 8.3
                   laravel: 9.*
@@ -30,6 +32,10 @@ jobs:
                   laravel: 11.*
                 - php: 8.1
                   laravel: 12.*
+                - php: 8.1
+                  laravel: 13.*
+                - php: 8.2
+                  laravel: 13.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-              php: [8.1, 8.2, 8.3, 8.4]
+              php: [8.1, 8.2, 8.3, 8.4, 8.5]
               laravel: [10.*, 11.*, 12.*, 13.*]
               dependency-version: [prefer-lowest, prefer-stable]
               include:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "illuminate/support": ">=9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
         "phpunit/phpunit": "^9.6|^10.5|^11.5",
         "nesbot/carbon": "^2.72.3|^3.0"
     },

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,6 +8,13 @@ use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
 {
+    /**
+     * Compatibility with newer Orchestra Testbench / PHPUnit internals.
+     *
+     * @var \Illuminate\Testing\TestResponse|null
+     */
+    protected static $latestResponse;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,7 +13,7 @@ class TestCase extends Orchestra
      *
      * @var \Illuminate\Testing\TestResponse|null
      */
-    protected static $latestResponse;
+    public static $latestResponse;
 
     public function setUp(): void
     {


### PR DESCRIPTION
## Summary
- add Laravel 13 to the GitHub Actions test matrix
- add Orchestra Testbench 11 for Laravel 13 package testing
- exclude unsupported PHP/Laravel combinations for Laravel 13

## Verification
- composer update --prefer-stable --prefer-dist --no-interaction with laravel/framework:13.* and orchestra/testbench:^11.0
- vendor/bin/phpunit